### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "ruby"
+run = "run"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Legend of the Sourcerer is an open-source text-based adventure game written in Ruby.
 
+[![Run on Repl.it](https://repl.it/badge/github/sourcerer-io/lots)](https://repl.it/github/sourcerer-io/lots)
+
 https://blog.sourcerer.io/legend-of-the-sourcerer-a-text-based-adventure-game-in-ruby-9220b385ca1e
 
 # Credits 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@tropper80/lots).